### PR TITLE
komga: add pagination for chapter list

### DIFF
--- a/extensions/komga/metadata.json
+++ b/extensions/komga/metadata.json
@@ -2,7 +2,7 @@
   "id": "b21fcfa9-8b46-439f-b060-31832aaf1931",
   "name": "Komga",
   "url": "https://komga.org",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "translatedLanguage": "MULTI",
   "hasSettings": true,
   "notice": "Set your host info in the extension settings.",


### PR DESCRIPTION
Komga: handling pagination on the chapter list, so that it's not limited to 20 chapters. Pagination for the library/series list is already handled by the base client behavior.

fixes #68 